### PR TITLE
Documentation and Code Reorganization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ debug
 
 /build/
 /cmake-build-debug/
+/src/ssb/data/

--- a/src/operators/Aggregate.cpp
+++ b/src/operators/Aggregate.cpp
@@ -350,12 +350,12 @@ void Aggregate::finish() {
     sort();
 
     for (auto &group_values : groups_) {
-        output_tabl_data_.push_back(group_values.make_array()->data());
+        output_table_data_.push_back(group_values.make_array()->data());
     }
-    output_tabl_data_.push_back(aggregates_.make_array()->data());
+    output_table_data_.push_back(aggregates_.make_array()->data());
 
-    output_tabl_->insert_records(output_tabl_data_);
-    output_result_->append(output_tabl_);
+    output_table_->insert_records(output_table_data_);
+    output_result_->append(output_table_);
 }
 
 arrow::compute::Datum Aggregate::compute_aggregate(
@@ -420,7 +420,7 @@ void Aggregate::initialize() {
     out_schema_ = get_output_schema(aggregate_refs_[0].kernel,
                                     aggregate_refs_[0].agg_name);
     //Initialize output table.
-    output_tabl_ = std::make_shared<Table>("aggregate", out_schema_, BLOCK_SIZE);
+    output_table_ = std::make_shared<Table>("aggregate", out_schema_, BLOCK_SIZE);
 
     // Fetch unique values for all Group By columns.
     for (auto &col_ref : group_by_refs_) {
@@ -553,7 +553,7 @@ void Aggregate::sort() {
 
         // A nullptr indicates that we are sorting by the aggregate column
         // TODO(nicholas): better way to indicate we want to sort the aggregate?
-        if (order_ref.table == output_tabl_) {
+        if (order_ref.table == output_table_) {
             sort_to_indices(aggregates_, &sorted_indices);
         } else {
             auto group = groups_[order_to_group[i]];

--- a/src/operators/Aggregate.cpp
+++ b/src/operators/Aggregate.cpp
@@ -330,7 +330,7 @@ std::shared_ptr<arrow::ChunkedArray> Aggregate::get_unique_value_filter
     arrow::ArrayVector filter_vector;
 
     auto group_by_col = group_by_cols_[group_ref.col_name];
-    
+
     // TODO(nicholas): spawn a new task for each block
     for (int i = 0; i < group_by_col->num_chunks(); i++) {
 
@@ -591,20 +591,16 @@ void Aggregate::sort() {
 
     // If we are sorting after computing all aggregates, we evaluate the ORDER BY
     // clause in reverse order.
-    std::reverse(order_by_refs_.begin(), order_by_refs_.end());
-    for (int i=0; i<order_by_refs_.size(); i++) {
+    for (int i=order_by_refs_.size()-1; i>=0; i--) {
 
         auto order_ref = order_by_refs_[i];
 
         if (order_ref.table == nullptr) {
             sort_to_indices(aggregates_, &sorted_indices);
-            sort_datum(aggregates_, &aggregates_);
-
         } else {
             auto group = groups_[order_to_group[i]];
             sort_to_indices(group, &sorted_indices);
         }
-
         apply_indices(aggregates_, sorted_indices, &aggregates_);
 
         for (auto &group: groups_) {

--- a/src/operators/Aggregate.cpp
+++ b/src/operators/Aggregate.cpp
@@ -325,24 +325,15 @@ arrow::compute::Datum Aggregate::get_unique_values(
 std::shared_ptr<arrow::ChunkedArray> Aggregate::get_unique_value_filter
     (const ColumnReference& group_ref, arrow::compute::Datum value) {
 
-    arrow::Status status;
-    arrow::compute::FunctionContext function_context(
-        arrow::default_memory_pool());
-    arrow::compute::CompareOptions compare_options(
-        arrow::compute::CompareOperator::EQUAL);
     arrow::compute::Datum out_filter;
     arrow::ArrayVector filter_vector;
 
-//    auto group_by_col = prev_result_->get_table(group_ref.table)
-//        .get_column_by_name(group_ref.col_name);
     auto group_by_col = group_by_cols_[group_ref.col_name];
 
     for (int i = 0; i < group_by_col->num_chunks(); i++) {
 
         auto block_col = group_by_col->chunk(i);
-        status = arrow::compute::Compare(
-            &function_context, block_col, value, compare_options, &out_filter);
-        evaluate_status(status, __FUNCTION__, __LINE__);
+        compare(block_col, value, arrow::compute::CompareOperator::EQUAL, &out_filter);
 
         filter_vector.push_back(out_filter.make_array());
     }

--- a/src/operators/Aggregate.cpp
+++ b/src/operators/Aggregate.cpp
@@ -350,12 +350,12 @@ void Aggregate::finish() {
     sort();
 
     for (auto &group_values : groups_) {
-        out_table_data_.push_back(group_values.make_array()->data());
+        output_tabl_data_.push_back(group_values.make_array()->data());
     }
-    out_table_data_.push_back(aggregates_.make_array()->data());
+    output_tabl_data_.push_back(aggregates_.make_array()->data());
 
-    out_table_->insert_records(out_table_data_);
-    output_result_->append(out_table_);
+    output_tabl_->insert_records(output_tabl_data_);
+    output_result_->append(output_tabl_);
 }
 
 arrow::compute::Datum Aggregate::compute_aggregate(
@@ -420,7 +420,7 @@ void Aggregate::initialize() {
     out_schema_ = get_output_schema(aggregate_refs_[0].kernel,
                                     aggregate_refs_[0].agg_name);
     //Initialize output table.
-    out_table_ = std::make_shared<Table>("aggregate", out_schema_, BLOCK_SIZE);
+    output_tabl_ = std::make_shared<Table>("aggregate", out_schema_, BLOCK_SIZE);
 
     // Fetch unique values for all Group By columns.
     for (auto &col_ref : group_by_refs_) {
@@ -553,7 +553,7 @@ void Aggregate::sort() {
 
         // A nullptr indicates that we are sorting by the aggregate column
         // TODO(nicholas): better way to indicate we want to sort the aggregate?
-        if (order_ref.table == nullptr) {
+        if (order_ref.table == output_tabl_) {
             sort_to_indices(aggregates_, &sorted_indices);
         } else {
             auto group = groups_[order_to_group[i]];

--- a/src/operators/Aggregate.cpp
+++ b/src/operators/Aggregate.cpp
@@ -140,24 +140,32 @@ Aggregate::get_group_filter(std::vector<int> group_id) {
 
         switch (group_type_->child(field_i)->type()->id()) {
             case arrow::Type::STRING: {
-                auto one_unique_values_casted =
+                // Downcast an Array of unique values.
+                auto one_unique_value_casted =
                     std::static_pointer_cast<arrow::StringArray>
                         (all_unique_values_[field_i]);
+                // Fetch a particular unique value from the array specified by
+                // the group_id
                 value = arrow::compute::Datum(
                     std::make_shared<arrow::StringScalar>(
-                        one_unique_values_casted->GetString(
+                        one_unique_value_casted->GetString(
                             group_id[field_i])));
+                // Get the filter for this particular unique value.
                 next_filter = get_unique_value_filter(group_by_refs_[field_i],
                                                       value);
                 break;
             }
             case arrow::Type::INT64: {
-                auto one_unique_values_casted =
+                // Downcast an Array of unique values.
+                auto one_unique_value_casted =
                     std::static_pointer_cast<arrow::Int64Array>
                         (all_unique_values_[field_i]);
+                // Fetch a particular unique value from the array specified by
+                // the group_id
                 value = arrow::compute::Datum(
                     std::make_shared<arrow::Int64Scalar>(
-                        one_unique_values_casted->Value(group_id[field_i])));
+                        one_unique_value_casted->Value(group_id[field_i])));
+                // Get the filter for this particular unique value.
                 next_filter = get_unique_value_filter(group_by_refs_[field_i],
                                                       value);
                 break;

--- a/src/operators/Aggregate.h
+++ b/src/operators/Aggregate.h
@@ -96,7 +96,9 @@ private:
 
     bool sort_aggregate_col_;
     std::vector<std::shared_ptr<arrow::Array>> sorted_groups_;
-    std::shared_ptr<arrow::Array> aggregates_;
+    std::shared_ptr<arrow::Array> aggs_;
+    arrow::compute::Datum aggregates_;
+//    arrow::compute::Datum aggs_;
 
     std::unordered_map<std::string, std::shared_ptr<arrow::ChunkedArray>> group_by_cols_;
 

--- a/src/operators/Aggregate.h
+++ b/src/operators/Aggregate.h
@@ -178,7 +178,7 @@ private:
      */
     arrow::compute::Datum compute_aggregate(
         AggregateKernels kernel,
-        std::shared_ptr<arrow::ChunkedArray> aggregate_col);
+        arrow::compute::Datum aggregate_col);
 
 
     /**
@@ -238,7 +238,7 @@ private:
     void initialize();
 
     void compute_group_aggregate(int agg_index, std::vector<int> group_id,
-                                 std::shared_ptr<arrow::ChunkedArray> agg_col);
+                                 arrow::compute::Datum agg_col);
 
 
 };

--- a/src/operators/Aggregate.h
+++ b/src/operators/Aggregate.h
@@ -153,7 +153,7 @@ private:
      * @return The schema for the output table.
      */
     std::shared_ptr<arrow::Schema> get_output_schema(
-        AggregateKernels kernel, std::string agg_col_name);
+        AggregateKernels kernel, const std::string& agg_col_name);
 
     /**
      * Construct an ArrayBuilder for the aggregate values.
@@ -178,7 +178,7 @@ private:
      */
     arrow::compute::Datum compute_aggregate(
         AggregateKernels kernel,
-        arrow::compute::Datum aggregate_col);
+        const arrow::compute::Datum& aggregate_col);
 
 
     /**
@@ -195,7 +195,7 @@ private:
      *
      * @param aggregate The aggregate computed for a single group.
      */
-    bool insert_group_aggregate(arrow::compute::Datum aggregate, int agg_index);
+    bool insert_group_aggregate(const arrow::compute::Datum& aggregate, int agg_index);
 
     /**
      * Get the filter corresponding to a single group across all group by
@@ -209,7 +209,7 @@ private:
      */
     arrow::compute::Datum get_group_filter(std::vector<int> its);
 
-    arrow::compute::Datum get_unique_values(ColumnReference group_ref);
+    arrow::compute::Datum get_unique_values(const ColumnReference& group_ref);
 
     /**
      * Get the filter corresponding to a single group of a single column.
@@ -222,7 +222,7 @@ private:
      * i.e. the filter corresponding to a single group of col_ref.
      */
     std::shared_ptr<arrow::ChunkedArray> get_unique_value_filter(
-        ColumnReference col_ref,
+        const ColumnReference& col_ref,
         arrow::compute::Datum value);
 
     /**
@@ -237,7 +237,7 @@ private:
 
     void initialize();
 
-    void compute_group_aggregate(int agg_index, std::vector<int> group_id,
+    void compute_group_aggregate(int agg_index, const std::vector<int>& group_id,
                                  arrow::compute::Datum agg_col);
 
 

--- a/src/operators/Aggregate.h
+++ b/src/operators/Aggregate.h
@@ -63,6 +63,11 @@ public:
      *
      * Due to limitations in Arrow, we only support sorting in ascending order.
      *
+     * Sorting by the aggregate column is a bit hacky. We need to input a
+     * ColumnReference for the aggregate column, but the table containing the
+     * aggregate column does not actually exist until we execute the Aggregate
+     * operator. For now, I let
+     *
      * @param prev_result OperatorResult form an upstream operator.
      * @param aggregate_ref vector of AggregateReferences denoting which
      * columns we want to perform an aggregate on and which aggregate to
@@ -104,9 +109,9 @@ private:
     // The output table's schema
     std::shared_ptr<arrow::Schema> out_schema_;
     // The new output table containing the group columns and aggregate columns.
-    std::shared_ptr<Table> out_table_;
+    std::shared_ptr<Table> output_table_;
     // The output table's data.
-    std::vector<std::shared_ptr<arrow::ArrayData>> out_table_data_;
+    std::vector<std::shared_ptr<arrow::ArrayData>> output_table_data_;
 
     // Group columns for the output table.
     std::vector<arrow::compute::Datum> groups_;
@@ -276,6 +281,10 @@ private:
      * with respect to R.b, and then sort with respect to R.a.
      */
     void sort();
+
+    inline std::shared_ptr<Table> get_output_table() {
+        return output_table_;
+    }
 
 
 };

--- a/src/operators/Aggregate.h
+++ b/src/operators/Aggregate.h
@@ -207,9 +207,9 @@ private:
      * @return A filter corresponding to rows of the aggregate column
      * associated with the group defined by the its array.
      */
-    std::shared_ptr<arrow::ChunkedArray> get_group_filter(std::vector<int> its);
+    arrow::compute::Datum get_group_filter(std::vector<int> its);
 
-    std::shared_ptr<arrow::Array> get_unique_values(ColumnReference group_ref);
+    arrow::compute::Datum get_unique_values(ColumnReference group_ref);
 
     /**
      * Get the filter corresponding to a single group of a single column.

--- a/src/operators/Aggregate.h
+++ b/src/operators/Aggregate.h
@@ -37,10 +37,12 @@ struct AggregateReference {
 /**
  * Group = a set of column values, one for each column in the GROUP BY clause
  *
+ * Pseudo code:
+ *
  * Initialize an empty output table T
  * Fetch all the unique value of each column in the GROUP BY clause
- * If the aggregate column does not appear in the ORDER BY clause
- *   sort the unique values according to the ORDER BY clause
+ * If the aggregate column does not appear in the ORDER BY clause:
+ *   Sort the unique values as specified by the ORDER BY clause
  *
  * Iterate over all possible groups G:
  *   Get a filter for each column value in G
@@ -50,13 +52,25 @@ struct AggregateReference {
  *   If the aggregate is > 0:
  *      Insert the tuple (G, aggregate) into T
  *
+ * If the aggregate column appears in the ORDER BY clause:
+ *   Sort T with as specified by the ORDER BY clause
+ *
+ * If the aggregate column does not appear in the ORDER BY clause, then by
+ * sorting unique values prior to computing any group aggregates, we assure
+ * that the order in which we iterate over groups G is the order in which the
+ * tuples should appear in the output table.
+ *
+ * If the aggregate column appears in the ORDER BY clause, of course we must
+ * sort only after all group aggregates have been computed. Then we sort the
+ * columns of T with respect to columns in the ORDER BY clause but in the
+ * reverse order in which they appear. 
  */
 class Aggregate : public Operator {
 public:
 
     /**
      * Construct an Aggregate operator. Group by and order by clauses are
-     * evaluated from left to right. If there is no group byor order by
+     * evaluated from left to right. If there is no group by or order by
      * clause, simply pass in an empty vector.
      *
      * Due to limitations in Arrow, we only support sorting in ascending order.
@@ -94,30 +108,22 @@ public:
 
 private:
 
-    bool sort_aggregate_col_;
-    std::vector<arrow::compute::Datum> groups_;
-    arrow::compute::Datum aggregates_;
-
-    std::unordered_map<std::string, std::shared_ptr<arrow::ChunkedArray>> group_by_cols_;
-
-    std::shared_ptr<arrow::ChunkedArray> empty_filter_;
-    // If a thread wants to insert a group and its aggregate into group_builder_
-    // and aggregate_builder_, then it must grab this mutex. Otherwise, another
-    // thread may insert a different aggregate, associating the group with an
-    // incorrect aggregate.
-    std::mutex builder_mutex_;
+    // Operator result from an upstream operator
+    std::shared_ptr<OperatorResult> prev_result_;
+    // Where the output result will be stored
+    std::shared_ptr<OperatorResult> output_result_;
 
     // The output table's schema
     std::shared_ptr<arrow::Schema> out_schema_;
-    // The output table's data.
-    std::vector<std::shared_ptr<arrow::ArrayData>> out_table_data_;
     // The new output table containing the group columns and aggregate columns.
     std::shared_ptr<Table> out_table_;
+    // The output table's data.
+    std::vector<std::shared_ptr<arrow::ArrayData>> out_table_data_;
 
-
-    // Operator result from an upstream operator
-    std::shared_ptr<OperatorResult> prev_result_;
-    std::shared_ptr<OperatorResult> output_result_;
+    // Group columns for the output table.
+    std::vector<arrow::compute::Datum> groups_;
+    // Aggregate column for the output table.
+    arrow::compute::Datum aggregates_;
 
     // References denoting which columns we want to perform an aggregate on
     // and which aggregate to perform.
@@ -127,21 +133,55 @@ private:
     // References denoting which columns we want to group by
     std::vector<ColumnReference> order_by_refs_;
 
-    std::vector<int64_t> tuple_ordering_;
+    // Flag indicating whether or not the aggregate column is included in the
+    // ORDER BY clause
+    bool sort_aggregate_col_;
 
-    // We append each aggregate to this after it is computed.
-    std::shared_ptr<arrow::ArrayBuilder> aggregate_builder_;
+    // Map group by column names to the actual group column
+    std::unordered_map<std::string, std::shared_ptr<arrow::ChunkedArray>> group_by_cols_;
 
-    // A StructType containing the types of all group by columns
-    std::shared_ptr<arrow::DataType> group_type_;
-    // We append each group to this after we compute the aggregate for that
-    // group.
-    std::shared_ptr<arrow::StructBuilder> group_builder_;
     // A vector of Arrays containing the unique values of each of the group
     // by columns.
     std::vector<std::shared_ptr<arrow::Array>> all_unique_values_;
 
-    void sort();
+    // A StructType containing the types of all group by columns
+    std::shared_ptr<arrow::DataType> group_type_;
+    // We append each aggregate to this after it is computed.
+    std::shared_ptr<arrow::ArrayBuilder> aggregate_builder_;
+    // We append each group to this after we compute the aggregate for that
+    // group.
+    std::shared_ptr<arrow::StructBuilder> group_builder_;
+    // If a thread wants to insert a group and its aggregate into group_builder_
+    // and aggregate_builder_, then it must grab this mutex to ensure that the
+    // groups and its aggregates are inserted at the same row.
+    std::mutex builder_mutex_;
+
+    // In a multithreaded setting, we cannot guarantee that aggregates are computed
+    // and inserted into aggregate_builder_ in the correct order even though we
+    // assign single-group aggregation tasks in the correct order. So, we assign
+    // each task an index (see agg_index in compute_aggregates()) which is equal
+    // to the index at which the aggregate resides when the output is correctly
+    // ordered. When an aggregate is inserted into aggregate_builder_, we also
+    // append it's agg_index to tuple_ordering_. So, tuple_ordering_ maps the
+    // aggregate's current index to its correctly sorted index. For example,
+    // say we have two groups A and B with agg_index 0 and 1, respectively. If
+    // B's aggregate is computed before A's, then our output looks like
+    //
+    // B agg_B
+    // A agg_A
+    //
+    // and tuple_ordering = {1 , 0}. Sorting our output by the indices in
+    // tuple_ordering_ gives us the correct result:
+    //
+    // A agg_A
+    // B agg_B
+    std::vector<int64_t> tuple_ordering_;
+
+
+    /**
+     * Initialize or pre-compute data members.
+     */
+    void initialize();
 
     /**
      * Construct the schema for the output table.
@@ -166,41 +206,33 @@ private:
         AggregateKernels kernel);
 
     /**
-     * Compute the aggregate for a single group.
-     *
-     * @param kernel The type of aggregate we want to compute
-     * @param aggregate_col The column over which we want to compute the
-     * aggregate.
-     * @param group_filter A filter corresponding to all rows in the table
-     * that are part of a particular group.
-     *
-     * @return A Scalar Datum containing the aggregate
+     * @return A vector of ArrayBuilders, one for each of the group by columns.
      */
-    arrow::compute::Datum compute_aggregate(
-        AggregateKernels kernel,
-        const arrow::compute::Datum& aggregate_col);
-
+    std::vector<std::shared_ptr<arrow::ArrayBuilder>> get_group_builders();
 
     /**
-     * Insert a particular group into the group_builder_
+     * Get the unique values of a particular column specified by a
+     * ColumnReference.
      *
-     * @param its indices corresponding to values in unique_values_, e.g.
-     * passing in its = [0, 3, 7] would insert unique_values_[0],
-     * unique_values_[3], and unique_values_[7], into group_builder_.
+     * @param group_ref a ColumnReference indicating which column's unique
+     * values we want
+     * @return the column's unique values as an Array.
      */
-    void insert_group(std::vector<int> its);
+    arrow::compute::Datum get_unique_values(const ColumnReference& group_ref);
 
     /**
-     * Insert the aggregate of a single group into aggregate_builder_.
+     * Loop over all aggregate groups and compute the aggreate for each group.
+     * A new task is spawned for each group aggregate to be computed.
      *
-     * @param aggregate The aggregate computed for a single group.
+     * @param ctx scheduler task
      */
-    bool insert_group_aggregate(const arrow::compute::Datum& aggregate, int agg_index);
+    void compute_aggregates(Task *ctx);
 
     /**
      * Get the filter corresponding to a single group across all group by
      * columns. This is achieved by first getting the filters for a single
-     * group of a single column and then ANDing all of the filters.
+     * group of a single column (by calling get_unique_value_filter()) and then
+     * ANDing all of the filters.
      *
      * @param its indices corresponding to values in unique_values_
      *
@@ -208,8 +240,6 @@ private:
      * associated with the group defined by the its array.
      */
     arrow::compute::Datum get_group_filter(std::vector<int> its);
-
-    arrow::compute::Datum get_unique_values(const ColumnReference& group_ref);
 
     /**
      * Get the filter corresponding to a single group of a single column.
@@ -226,19 +256,59 @@ private:
         arrow::compute::Datum value);
 
     /**
-     * @return A vector of ArrayBuilders corresponding to each of the group
-     * by columns.
+     * Compute the aggregate over a single group. This calls compute_aggregate()
+     * after applying a group filter to the aggregate column.
+     *
+     * @param agg_index The aggregate's sorted position in the final output
+     * @param group_id indices corresponding to values in unique_values_, e.g.
+     * passing in group_id = [0, 3, 7] would insert unique_values_[0],
+     * unique_values_[3], and unique_values_[7], into group_builder_.
+     * @param agg_col aggregate column
      */
-    std::vector<std::shared_ptr<arrow::ArrayBuilder>> get_group_builders();
-
-    void compute_aggregates(Task *ctx);
-
-    void finish();
-
-    void initialize();
-
     void compute_group_aggregate(int agg_index, const std::vector<int>& group_id,
                                  arrow::compute::Datum agg_col);
+
+    /**
+     * Compute the aggregate over a column.
+     *
+     * @param kernel The type of aggregate we want to compute
+     * @param aggregate_col The column over which we want to compute the
+     * aggregate.
+     *
+     * @return A Scalar Datum containing the aggregate
+     */
+    arrow::compute::Datum compute_aggregate(
+        AggregateKernels kernel,
+        const arrow::compute::Datum& aggregate_col);
+
+    /**
+     * Insert a particular group into the group_builder_
+     *
+     * @param group_id indices corresponding to values in unique_values_, e.g.
+     * passing in group_id = [0, 3, 7] would insert unique_values_[0],
+     * unique_values_[3], and unique_values_[7], into group_builder_.
+     */
+    void insert_group(std::vector<int> grooup_id);
+
+    /**
+     * Insert the aggregate of a single group into aggregate_builder_.
+     *
+     * @param aggregate The aggregate computed for a single group.
+     */
+    bool insert_group_aggregate(const arrow::compute::Datum& aggregate, int agg_index);
+
+    /**
+     * Create the output result from data computed during operator execution.
+     */
+    void finish();
+
+    /**
+     * If the aggregate column appears in the ORDER BY clause, we must sort
+     * after all group aggregates have been computed. This sorts the output data
+     * with respect to each column in the ORDER BY clause, but in the reverse
+     * order in which they appear.
+     */
+    void sort();
 
 
 };

--- a/src/operators/Aggregate.h
+++ b/src/operators/Aggregate.h
@@ -95,10 +95,8 @@ public:
 private:
 
     bool sort_aggregate_col_;
-    std::vector<std::shared_ptr<arrow::Array>> sorted_groups_;
-    std::shared_ptr<arrow::Array> aggs_;
+    std::vector<arrow::compute::Datum> groups_;
     arrow::compute::Datum aggregates_;
-//    arrow::compute::Datum aggs_;
 
     std::unordered_map<std::string, std::shared_ptr<arrow::ChunkedArray>> group_by_cols_;
 

--- a/src/operators/CMakeLists.txt
+++ b/src/operators/CMakeLists.txt
@@ -17,6 +17,7 @@ target_include_directories(hustle_src_operators PUBLIC ${ARROW_INCLUDE_DIR})
 target_link_libraries(hustle_src_operators PUBLIC
         hustle_src_table
         hustle_src_utils_EventProfiler
+        hustle_src_utils_ArrowComputeWrappers
         ${ARROW_SHARED_LIB}
 )
 

--- a/src/operators/Join.h
+++ b/src/operators/Join.h
@@ -11,6 +11,12 @@
 
 namespace hustle::operators {
 
+/**
+ * The Join operator updates the index arrays of each LazyTable in the inputted
+ * OperatorResults. After execution, the index arrays of each LazyTable contains
+ * only the indices of rows that join with all other LazyTables this LazyTable
+ * was joined with. Filters are unchanged.
+ */
 class Join : public Operator {
 public:
 
@@ -37,29 +43,44 @@ public:
 
 private:
 
+    // lefts[i] = the left table in the ith join
     std::vector<LazyTable> lefts;
+    // rights[i] = the right table in the ith join
     std::vector<LazyTable> rights;
+    // left_col_names[i] = the left join col name in the ith join
     std::vector<std::string> left_col_names;
+    // right_col_names[i] = the right join col name in the ith join
     std::vector<std::string> right_col_names;
 
-    // Operator result from an upstream operator
+    // Results from upstream operators
     std::vector<std::shared_ptr<OperatorResult>> prev_result_vec_;
+    // Results from upstream operators condensed into one object
     std::shared_ptr<OperatorResult> prev_result_;
+    // Where the output result will be stored once the operator is executed.
     std::shared_ptr<OperatorResult> output_result_;
 
     // A graph specifying all join predicates
     JoinGraph graph_;
 
-
+    // Hash table for the right table in each join
     std::unordered_map<int64_t, int64_t> hash_table_;
 
+    // new_left_indices_vector[i] = the indices of rows joined in chunk i in
+    // the left table
     std::vector<std::vector<int64_t>> new_left_indices_vector;
+    // new_right_indices_vector[i] = the indices of rows joined in chunk i in
+    // the right table
     std::vector<std::vector<int64_t>> new_right_indices_vector;
 
-    std::vector<arrow::compute::Datum> joined_indices_;
+    // It would make much more sense to use an ArrayVector instead of a vector of
+    // vectors, since we can make a ChunkedArray out from an ArrayVector. But
+    // Arrow's Take function is very inefficient when the indices are in a
+    // ChunkedArray. So, we instead use a vector of vectors to store the indices,
+    // and then construct an Array from the vector of vectors.
 
-    std::mutex hash_table_mutex_;
-    std::mutex join_mutex_;
+    // joined_indices[0] = new_left_indices_vector stored as an Array
+    // joined_indices[1] = new_right_indices_vector stored as an Array
+    std::vector<arrow::compute::Datum> joined_indices_;
 
 
     /**
@@ -98,16 +119,34 @@ private:
      *
      * @param joined_indices A pair of index arrays corresponding to rows of
      * the left table that join with rows of the right table.
-     *
      * @return An OperatorResult containing the same LazyTables passed in as
      * prev_result, but now their index arrays are updated, i.e. all indices
      * that did not satisfy the join predicate are not included.
+     *
+     * e.g. Suppose we are join R with S and rows [0, 1] or R join with rows
+     * [2, 3] of S. Further suppose that rows [3] of S join with rows [4] of T.
+     * At this point, we know we can exclude one of the rows from the first join
+     * on R and S. back_propogate_result() would produce the following index
+     * arrays:
+     *
+     * R S T
+     * 1 3 4
+     *
      */
     std::shared_ptr<OperatorResult> back_propogate_result
         (LazyTable left, LazyTable right,
          std::vector<arrow::compute::Datum> joined_indices);
 
+    /**
+     * probe_hash_table() populates new_left_indices_vector
+     * and new_right_indices_vector. This function converts these into Arrow
+     * Arrays.
+     */
     void finish_probe();
+
+    /*
+     * Create the output result from the raw data computed during execution.
+     */
     void finish();
 
 };

--- a/src/operators/Join.h
+++ b/src/operators/Join.h
@@ -16,6 +16,9 @@ namespace hustle::operators {
  * OperatorResults. After execution, the index arrays of each LazyTable contains
  * only the indices of rows that join with all other LazyTables this LazyTable
  * was joined with. Filters are unchanged.
+ *
+ * See slides 18-27 for an in-depth example:
+ * https://docs.google.com/presentation/d/1KlNdwwTy5k-cwlRwY_hRg-AQ9dt3mh_k_MVuIsmyQbQ/edit#slide=id.p
  */
 class Join : public Operator {
 public:

--- a/src/operators/LIP.h
+++ b/src/operators/LIP.h
@@ -12,6 +12,13 @@
 
 namespace hustle::operators {
 
+/**
+ * The LIP operator updates the index array of the fact LazyTable in the inputted
+ * OperatorResults. After execution, the index array of the fact LazyTable contains
+ * the indices of rows that join with all other LazyTables the fact LazyTable
+ * was joined with and possibly with some extraneous indices (false positives).
+ * The index array of all other LazyTables are unchanged. Filters are unchanged.
+ */
 class LIP : public Operator {
 public:
 

--- a/src/operators/Select.h
+++ b/src/operators/Select.h
@@ -12,6 +12,14 @@
 
 namespace hustle::operators {
 
+/**
+ * The Select operator updates the filter of a LazyTable so that it filters out
+ * all tuples that do not satisfy the selection predicate.
+ *
+ * Predicates are inputted as a predicate tree. All internal nodes of the tree
+ * are connective operators (AND, OR), while leaf nodes are simple predicates,
+ * e.g. column = 7.
+ */
 class Select : public Operator {
 public:
 

--- a/src/operators/Select.h
+++ b/src/operators/Select.h
@@ -81,6 +81,9 @@ private:
         const std::shared_ptr<Predicate> &predicate,
         const std::shared_ptr<Block> &block);
 
+    /**
+     * Create the output result from the raw data computed during execution.
+     */
     void finish();
 };
 

--- a/src/ssb/main.cpp
+++ b/src/ssb/main.cpp
@@ -8,7 +8,7 @@ void read_from_csv() {
     std::shared_ptr<arrow::Schema> lo_schema, c_schema, s_schema, p_schema, d_schema;
 
 
-    auto field1 = arrow::field("order date", arrow::int64());
+    auto field1 = arrow::field("order key", arrow::int64());
     auto field2 = arrow::field("line number", arrow::int64());
     auto field3 = arrow::field("cust key", arrow::int64());
     auto field4 = arrow::field("part key", arrow::int64());

--- a/src/ssb/main.cpp
+++ b/src/ssb/main.cpp
@@ -2,45 +2,6 @@
 #include "../table/util.h"
 using namespace hustle::operators;
 
-int main(int argc, char *argv[]) {
-
-    SSB workload(1, false);
-
-    workload.q11();
-    workload.q12();
-    workload.q13();
-
-    workload.q21();
-    workload.q22();
-    workload.q23();
-
-    workload.q31();
-    workload.q32();
-    workload.q33();
-    workload.q34();
-
-    workload.q41();
-    workload.q42();
-    workload.q43();
-
-    workload.q11_lip();
-    workload.q12_lip();
-    workload.q13_lip();
-
-    workload.q21_lip();
-    workload.q22_lip();
-    workload.q23_lip();
-
-    workload.q31_lip();
-    workload.q32_lip();
-    workload.q33_lip();
-    workload.q34_lip();
-
-    workload.q41_lip();
-    workload.q42_lip();
-    workload.q43_lip();
-}
-
 void read_from_csv() {
 
     std::shared_ptr<Table> lo, c, s, p, d;
@@ -185,24 +146,66 @@ void read_from_csv() {
 
 
 
-    auto t = read_from_csv_file("/Users/corrado/h/hustle/src/ssb/data/ssb-10/customer.tbl", c_schema, BLOCK_SIZE);
-    write_to_file("/Users/corrado/h/hustle/src/ssb/data/ssb-10/customer.hsl", *t);
+    auto t = read_from_csv_file("/Users/corrado/hustle/src/ssb/data/ssb-01/customer.tbl", c_schema, BLOCK_SIZE);
+    write_to_file("/Users/corrado/hustle/src/ssb/data/ssb-01/customer.hsl", *t);
     std::cout << "c" << std::endl;
 
-    t = read_from_csv_file("/Users/corrado/h/hustle/src/ssb/data/ssb-10/supplier.tbl", s_schema, BLOCK_SIZE);
-    write_to_file("/Users/corrado/h/hustle/src/ssb/data/ssb-10/supplier.hsl", *t);
+    t = read_from_csv_file("/Users/corrado/hustle/src/ssb/data/ssb-01/supplier.tbl", s_schema, BLOCK_SIZE);
+    write_to_file("/Users/corrado/hustle/src/ssb/data/ssb-01/supplier.hsl", *t);
     std::cout << "s" << std::endl;
 
-    t = read_from_csv_file("/Users/corrado/h/hustle/src/ssb/data/ssb-10/lineorder.tbl", lo_schema, BLOCK_SIZE);
-    write_to_file("/Users/corrado/h/hustle/src/ssb/data/ssb-10/lineorder.hsl", *t);
+    t = read_from_csv_file("/Users/corrado/hustle/src/ssb/data/ssb-01/lineorder.tbl", lo_schema, BLOCK_SIZE);
+    write_to_file("/Users/corrado/hustle/src/ssb/data/ssb-01/lineorder.hsl", *t);
     std::cout << "lo" << std::endl;
 
-    t = read_from_csv_file("/Users/corrado/h/hustle/src/ssb/data/ssb-10/date.tbl", d_schema, BLOCK_SIZE);
-    write_to_file("/Users/corrado/h/hustle/src/ssb/data/ssb-10/date.hsl", *t);
+    t = read_from_csv_file("/Users/corrado/hustle/src/ssb/data/ssb-01/date.tbl", d_schema, BLOCK_SIZE);
+    write_to_file("/Users/corrado/hustle/src/ssb/data/ssb-01/date.hsl", *t);
     std::cout << "d" << std::endl;
 
-    t = read_from_csv_file("/Users/corrado/h/hustle/src/ssb/data/ssb-10/part.tbl", p_schema, BLOCK_SIZE);
-    write_to_file("/Users/corrado/h/hustle/src/ssb/data/ssb-10/part.hsl", *t);
+    t = read_from_csv_file("/Users/corrado/hustle/src/ssb/data/ssb-01/part.tbl", p_schema, BLOCK_SIZE);
+    write_to_file("/Users/corrado/hustle/src/ssb/data/ssb-01/part.hsl", *t);
     std::cout << "p" << std::endl;
 
+}
+
+
+int main(int argc, char *argv[]) {
+
+//    read_from_csv();
+
+    SSB workload(1, false);
+
+    workload.q11();
+    workload.q12();
+    workload.q13();
+
+    workload.q21();
+    workload.q22();
+    workload.q23();
+
+    workload.q31();
+    workload.q32();
+    workload.q33();
+    workload.q34();
+
+    workload.q41();
+    workload.q42();
+    workload.q43();
+
+    workload.q11_lip();
+    workload.q12_lip();
+    workload.q13_lip();
+
+    workload.q21_lip();
+    workload.q22_lip();
+    workload.q23_lip();
+
+    workload.q31_lip();
+    workload.q32_lip();
+    workload.q33_lip();
+    workload.q34_lip();
+
+    workload.q41_lip();
+    workload.q42_lip();
+    workload.q43_lip();
 }

--- a/src/ssb/ssb_workload.cpp
+++ b/src/ssb/ssb_workload.cpp
@@ -18,25 +18,25 @@ SSB::SSB(int SF, bool print) {
     print_ = print;
 
     if (SF==1) {
-        lo = read_from_file("/Users/corrado/hustle/data/ssb-1/lineorder.hsl");
-        d = read_from_file("/Users/corrado/hustle/data/ssb-1/date.hsl");
-        p = read_from_file("/Users/corrado/hustle/data/ssb-1/part.hsl");
-        c = read_from_file("/Users/corrado/hustle/data/ssb-1/customer.hsl");
-        s = read_from_file("/Users/corrado/hustle/data/ssb-1/supplier.hsl");
+        lo = read_from_file("/Users/corrado/hustle/data/ssb-01/lineorder.hsl");
+        d = read_from_file("/Users/corrado/hustle/data/ssb-01/date.hsl");
+        p = read_from_file("/Users/corrado/hustle/data/ssb-01/part.hsl");
+        c = read_from_file("/Users/corrado/hustle/data/ssb-01/customer.hsl");
+        s = read_from_file("/Users/corrado/hustle/data/ssb-01/supplier.hsl");
     }
     else if (SF==5) {
-        lo = read_from_file("/Users/corrado/h/hustle/src/ssb/data/lineorder.hsl");
-        d = read_from_file("/Users/corrado/h/hustle/src/ssb/data/date.hsl");
-        p = read_from_file("/Users/corrado/h/hustle/src/ssb/data/part.hsl");
-        c = read_from_file("/Users/corrado/h/hustle/src/ssb/data/customer.hsl");
-        s = read_from_file("/Users/corrado/h/hustle/src/ssb/data/supplier.hsl");
+        lo = read_from_file("/Users/corrado/hustle/src/ssb/data/ssb-05/lineorder.hsl");
+        d = read_from_file("/Users/corrado/hustle/src/ssb/data/ssb-05/date.hsl");
+        p = read_from_file("/Users/corrado/hustle/src/ssb/data/ssb-05/part.hsl");
+        c = read_from_file("/Users/corrado/hustle/src/ssb/data/ssb-05/customer.hsl");
+        s = read_from_file("/Users/corrado/hustle/src/ssb/data/ssb-05/supplier.hsl");
     }
     else if (SF==10) {
-        lo = read_from_file("/Users/corrado/h/hustle/src/ssb/data/ssb-10/lineorder.hsl");
-        d = read_from_file("/Users/corrado/h/hustle/src/ssb/data/ssb-10/date.hsl");
-        p = read_from_file("/Users/corrado/h/hustle/src/ssb/data/ssb-10/part.hsl");
-        c = read_from_file("/Users/corrado/h/hustle/src/ssb/data/ssb-10/customer.hsl");
-        s = read_from_file("/Users/corrado/h/hustle/src/ssb/data/ssb-10/supplier.hsl");
+        lo = read_from_file("/Users/corrado/hustle/src/ssb/data/ssb-10/lineorder.hsl");
+        d = read_from_file("/Users/corrado/hustle/src/ssb/data/ssb-10/date.hsl");
+        p = read_from_file("/Users/corrado/hustle/src/ssb/data/ssb-10/part.hsl");
+        c = read_from_file("/Users/corrado/hustle/src/ssb/data/ssb-10/customer.hsl");
+        s = read_from_file("/Users/corrado/hustle/src/ssb/data/ssb-10/supplier.hsl");
     }
 
     lo_d_ref = {lo, "order date"};

--- a/src/ssb/ssb_workload.cpp
+++ b/src/ssb/ssb_workload.cpp
@@ -18,11 +18,11 @@ SSB::SSB(int SF, bool print) {
     print_ = print;
 
     if (SF==1) {
-        lo = read_from_file("/Users/corrado/hustle/data/ssb-01/lineorder.hsl");
-        d = read_from_file("/Users/corrado/hustle/data/ssb-01/date.hsl");
-        p = read_from_file("/Users/corrado/hustle/data/ssb-01/part.hsl");
-        c = read_from_file("/Users/corrado/hustle/data/ssb-01/customer.hsl");
-        s = read_from_file("/Users/corrado/hustle/data/ssb-01/supplier.hsl");
+        lo = read_from_file("/Users/corrado/hustle/src/ssb/data/ssb-01/lineorder.hsl");
+        d = read_from_file("/Users/corrado/hustle/src/ssb/data/ssb-01/date.hsl");
+        p = read_from_file("/Users/corrado/hustle/src/ssb/data/ssb-01/part.hsl");
+        c = read_from_file("/Users/corrado/hustle/src/ssb/data/ssb-01/customer.hsl");
+        s = read_from_file("/Users/corrado/hustle/src/ssb/data/ssb-01/supplier.hsl");
     }
     else if (SF==5) {
         lo = read_from_file("/Users/corrado/hustle/src/ssb/data/ssb-05/lineorder.hsl");

--- a/src/utils/BloomFilter.cpp
+++ b/src/utils/BloomFilter.cpp
@@ -59,8 +59,8 @@ void BloomFilter::insert(long long val) {
     // Hash the value using all hash functions
     int index;
     for (int k=0; k<num_hash_; k++) {
-        index = xxh::xxhash<64>(&val, sizeof(val), seeds_[k]) % num_cells_;
-//        index = hash(val, seeds_[k]) % num_cells_;
+//        index = xxh::xxhash<64>(&val, sizeof(val), seeds_[k]) % num_cells_;
+        index = hash(val, seeds_[k]) % num_cells_;
         cells_[index/8] |= (1u << (index % 8u));
     }
 
@@ -95,8 +95,8 @@ bool BloomFilter::probe(long long val){
     probe_count_++;
     int index;
     for(int i=0; i<num_hash_; i++){
-        index = xxh::xxhash<64>(&val, sizeof(val), seeds_[i]) % num_cells_;
-//        index = hash(val, seeds_[i]) % num_cells_;
+//        index = xxh::xxhash<64>(&val, sizeof(val), seeds_[i]) % num_cells_;
+        index = hash(val, seeds_[i]) % num_cells_;
         int bit = cells_[index/8] & (1u << (index % 8u));
         if (!bit) {
             return false;
@@ -118,11 +118,11 @@ bool BloomFilter::compare(std::shared_ptr<BloomFilter> lhs, std::shared_ptr<Bloo
 }
 
 
-//inline unsigned int BloomFilter::hash(long long x, int seed) {
-//    x = (x<<32)^seed;
-//    x = ((x >> 16) ^ x) * 0x45d9f3b;
-//    x = ((x >> 16) ^ x) * 0x45d9f3b;
-//    x = (x >> 16) ^ x;
-//    return x;
-//}
+inline unsigned int BloomFilter::hash(long long x, int seed) {
+    x = (x<<32)^seed;
+    x = ((x >> 16) ^ x) * 0x45d9f3b;
+    x = ((x >> 16) ^ x) * 0x45d9f3b;
+    x = (x >> 16) ^ x;
+    return x;
+}
 

--- a/src/utils/BloomFilter.h
+++ b/src/utils/BloomFilter.h
@@ -117,13 +117,12 @@ private:
 
 
     /**
-     * Knuth's multiplicative hash function
      *
      * @param val value to hash
      * @param seed random seed
      * @return a 32-bit hash value
      */
-//    unsigned int hash(long long val, int seed);
+    unsigned int hash(long long val, int seed);
 
     void Reset();
 

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -25,10 +25,14 @@ add_library(hustle_src_utils_EventProfiler EventProfiler.cpp EventProfiler.hpp)
 add_library(hustle_src_utils_Macros ../empty_src.cpp Macros.hpp)
 add_library(hustle_src_utils_SyncStream ../empty_src.cpp SyncStream.hpp)
 add_library(hustle_src_utils_ThreadSafeQueue ../empty_src.cpp ThreadSafeQueue.hpp)
+add_library(hustle_src_utils_ArrowComputeWrappers arrow_compute_wrappers.cpp arrow_compute_wrappers.h)
+
 #add_library(hustle_src_utils_BloomFilter BloomFilter.cpp BloomFilter.h)
 
 # Include Arrow
 #target_include_directories(hustle_src_utils_BloomFilter PUBLIC ${ARROW_INCLUDE_DIR})
+target_include_directories(hustle_src_utils_ArrowComputeWrappers PUBLIC ${ARROW_INCLUDE_DIR})
+
 
 # Link dependencies:
 target_link_libraries(hustle_src_utils_EventProfiler
@@ -39,6 +43,9 @@ target_link_libraries(hustle_src_utils_SyncStream
         hustle_src_utils_Macros)
 target_link_libraries(hustle_src_utils_ThreadSafeQueue
         hustle_src_utils_Macros)
+target_link_libraries(hustle_src_utils_ArrowComputeWrappers
+        absl::hash
+        ${ARROW_SHARED_LIB})
 #target_link_libraries(hustle_src_utils_BloomFilter PUBLIC
 #        ${ARROW_SHARED_LIB}
 #        )

--- a/src/utils/arrow_compute_wrappers.cpp
+++ b/src/utils/arrow_compute_wrappers.cpp
@@ -64,6 +64,30 @@ void apply_indices(
     evaluate_status(status, __PRETTY_FUNCTION__, __LINE__);
 }
 
+void sort_to_indices(const std::shared_ptr<arrow::Array>& values, std::shared_ptr<arrow::Array>* out) {
+
+    arrow::Status status;
+    arrow::compute::FunctionContext function_context(arrow::default_memory_pool());
+
+    status = arrow::compute::SortToIndices(&function_context, *values, out);
+    evaluate_status(status, __PRETTY_FUNCTION__, __LINE__);
+}
+
+void sort_to_indices(const arrow::compute::Datum& values, arrow::compute::Datum* out) {
+
+    assert(values.kind() == arrow::compute::Datum::ARRAY);
+
+    arrow::Status status;
+    arrow::compute::FunctionContext function_context(arrow::default_memory_pool());
+
+    std::shared_ptr<arrow::Array> temp;
+    status = arrow::compute::SortToIndices(&function_context, *values.make_array().get(), &temp);
+    evaluate_status(status, __PRETTY_FUNCTION__, __LINE__);
+
+    out->value = temp->data();
+
+}
+
 
 
 

--- a/src/utils/arrow_compute_wrappers.cpp
+++ b/src/utils/arrow_compute_wrappers.cpp
@@ -76,7 +76,6 @@ void sort_to_indices(const arrow::compute::Datum& values, arrow::compute::Datum*
     evaluate_status(status, __PRETTY_FUNCTION__, __LINE__);
 
     out->value = temp->data();
-
 }
 
 void sort_datum(const arrow::compute::Datum& values, arrow::compute::Datum* out) {
@@ -90,7 +89,20 @@ void sort_datum(const arrow::compute::Datum& values, arrow::compute::Datum* out)
 }
 
 
+void compare(
+    const arrow::compute::Datum& left,
+    const arrow::compute::Datum& right,
+    arrow::compute::CompareOperator compare_operator,
+    arrow::compute::Datum* out) {
 
+    arrow::Status status;
+    arrow::compute::CompareOptions compare_options(compare_operator);
+    arrow::compute::FunctionContext function_context(arrow::default_memory_pool());
+
+    status = arrow::compute::Compare(
+        &function_context, left, right, compare_options, out);
+    evaluate_status(status, __FUNCTION__, __LINE__);
+}
 
 
 }

--- a/src/utils/arrow_compute_wrappers.cpp
+++ b/src/utils/arrow_compute_wrappers.cpp
@@ -88,6 +88,17 @@ void sort_to_indices(const arrow::compute::Datum& values, arrow::compute::Datum*
 
 }
 
+void sort_datum(const arrow::compute::Datum& values, arrow::compute::Datum* out) {
+
+    assert(values.kind() == arrow::compute::Datum::ARRAY);
+
+    arrow::compute::Datum sorted_indices;
+
+    sort_to_indices(values, &sorted_indices);
+    apply_indices(values, sorted_indices, out);
+}
+
+
 
 
 

--- a/src/utils/arrow_compute_wrappers.cpp
+++ b/src/utils/arrow_compute_wrappers.cpp
@@ -114,5 +114,18 @@ void compare(
     evaluate_status(status, __FUNCTION__, __LINE__);
 }
 
+void unique(const arrow::compute::Datum& values, arrow::compute::Datum* out) {
+
+    arrow::Status status;
+    arrow::compute::FunctionContext function_context(arrow::default_memory_pool());
+    std::shared_ptr<arrow::Array> unique_values;
+
+    std::shared_ptr<arrow::Array> temp_array;
+    // Fetch the unique values in group_by_col
+    status = arrow::compute::Unique(&function_context, values, &temp_array);
+    evaluate_status(status, __FUNCTION__, __LINE__);
+
+    out->value = temp_array->data();
+}
 
 }

--- a/src/utils/arrow_compute_wrappers.cpp
+++ b/src/utils/arrow_compute_wrappers.cpp
@@ -1,0 +1,49 @@
+#include <assert.h>
+#include "arrow_compute_wrappers.h"
+#include "../table/util.h"
+
+namespace hustle {
+
+
+void apply_filter(
+    const arrow::compute::Datum& values,
+    const arrow::compute::Datum& filter,
+    arrow::compute::Datum* out) {
+
+    arrow::Status status;
+    arrow::compute::FunctionContext function_context(arrow::default_memory_pool());
+    arrow::compute::FilterOptions filter_options;
+
+    status = arrow::compute::Filter(&function_context,
+                                    values,
+                                    filter.chunked_array(),
+                                    filter_options,
+                                    out);
+
+    evaluate_status(status, __PRETTY_FUNCTION__, __LINE__);
+}
+
+void apply_indices(
+    const std::shared_ptr<arrow::ChunkedArray>& values,
+    const arrow::compute::Datum& indices,
+    std::shared_ptr<arrow::ChunkedArray>* out) {
+
+    assert(indices.kind() == arrow::compute::Datum::ARRAY);
+
+    arrow::Status status;
+    arrow::compute::FunctionContext function_context(arrow::default_memory_pool());
+    arrow::compute::TakeOptions take_options;
+
+    status = arrow::compute::Take(
+        &function_context,
+        *values,
+        *indices.make_array(),
+        take_options, out);
+
+    evaluate_status(status, __PRETTY_FUNCTION__, __LINE__);
+}
+
+
+
+
+}

--- a/src/utils/arrow_compute_wrappers.cpp
+++ b/src/utils/arrow_compute_wrappers.cpp
@@ -9,13 +9,6 @@ void apply_filter(
     const arrow::compute::Datum& values,
     const arrow::compute::Datum& filter,
     arrow::compute::Datum* out) {
-
-    assert(
-        (values.kind() == arrow::compute::Datum::CHUNKED_ARRAY &&
-         filter.kind() == arrow::compute::Datum::CHUNKED_ARRAY)||
-        (values.kind() == arrow::compute::Datum::ARRAY &&
-         filter.kind() == arrow::compute::Datum::ARRAY)
-     );
     
     arrow::Status status;
     arrow::compute::FunctionContext function_context(arrow::default_memory_pool());
@@ -38,6 +31,9 @@ void apply_filter(
                                             filter_options,
                                             out);
         }
+        default: {
+            std::cerr << "Value kind not supported" << std::endl;
+        }
     }
 
     evaluate_status(status, __PRETTY_FUNCTION__, __LINE__);
@@ -47,8 +43,6 @@ void apply_indices(
     const arrow::compute::Datum& values,
     const arrow::compute::Datum& indices,
     arrow::compute::Datum* out) {
-
-    assert(indices.kind() == arrow::compute::Datum::ARRAY);
 
     arrow::Status status;
     arrow::compute::FunctionContext function_context(arrow::default_memory_pool());
@@ -75,7 +69,7 @@ void apply_indices(
             break;
         }
         default:
-            std::cerr << "Value array kind not supported" << std::endl;
+            std::cerr << "Value kind not supported" << std::endl;
     }
 
 
@@ -83,8 +77,6 @@ void apply_indices(
 }
 
 void sort_to_indices(const arrow::compute::Datum& values, arrow::compute::Datum* out) {
-
-    assert(values.kind() == arrow::compute::Datum::ARRAY);
 
     arrow::Status status;
     arrow::compute::FunctionContext function_context(arrow::default_memory_pool());
@@ -97,8 +89,6 @@ void sort_to_indices(const arrow::compute::Datum& values, arrow::compute::Datum*
 }
 
 void sort_datum(const arrow::compute::Datum& values, arrow::compute::Datum* out) {
-
-    assert(values.kind() == arrow::compute::Datum::ARRAY);
 
     arrow::compute::Datum sorted_indices;
 

--- a/src/utils/arrow_compute_wrappers.cpp
+++ b/src/utils/arrow_compute_wrappers.cpp
@@ -10,6 +10,8 @@ void apply_filter(
     const arrow::compute::Datum& filter,
     arrow::compute::Datum* out) {
 
+    assert(filter.kind() == arrow::compute::Datum::CHUNKED_ARRAY);
+
     arrow::Status status;
     arrow::compute::FunctionContext function_context(arrow::default_memory_pool());
     arrow::compute::FilterOptions filter_options;
@@ -24,9 +26,9 @@ void apply_filter(
 }
 
 void apply_indices(
-    const std::shared_ptr<arrow::ChunkedArray>& values,
+    const arrow::compute::Datum& values,
     const arrow::compute::Datum& indices,
-    std::shared_ptr<arrow::ChunkedArray>* out) {
+    arrow::compute::Datum* out) {
 
     assert(indices.kind() == arrow::compute::Datum::ARRAY);
 
@@ -34,11 +36,30 @@ void apply_indices(
     arrow::compute::FunctionContext function_context(arrow::default_memory_pool());
     arrow::compute::TakeOptions take_options;
 
-    status = arrow::compute::Take(
-        &function_context,
-        *values,
-        *indices.make_array(),
-        take_options, out);
+    switch(values.kind()) {
+        case arrow::compute::Datum::NONE:
+            break;
+        case arrow::compute::Datum::ARRAY:
+            status = arrow::compute::Take(
+                &function_context,
+                values.make_array(),
+                indices.make_array(),
+                take_options, out);
+            break;
+        case arrow::compute::Datum::CHUNKED_ARRAY: {
+            std::shared_ptr<arrow::ChunkedArray> temp_chunked_array;
+            status = arrow::compute::Take(
+                &function_context,
+                *values.chunked_array(),
+                *indices.make_array(),
+                take_options, &temp_chunked_array);
+            out->value = temp_chunked_array;
+            break;
+        }
+        default:
+            std::cerr << "Value array kind not supported" << std::endl;
+    }
+
 
     evaluate_status(status, __PRETTY_FUNCTION__, __LINE__);
 }

--- a/src/utils/arrow_compute_wrappers.cpp
+++ b/src/utils/arrow_compute_wrappers.cpp
@@ -64,15 +64,6 @@ void apply_indices(
     evaluate_status(status, __PRETTY_FUNCTION__, __LINE__);
 }
 
-void sort_to_indices(const std::shared_ptr<arrow::Array>& values, std::shared_ptr<arrow::Array>* out) {
-
-    arrow::Status status;
-    arrow::compute::FunctionContext function_context(arrow::default_memory_pool());
-
-    status = arrow::compute::SortToIndices(&function_context, *values, out);
-    evaluate_status(status, __PRETTY_FUNCTION__, __LINE__);
-}
-
 void sort_to_indices(const arrow::compute::Datum& values, arrow::compute::Datum* out) {
 
     assert(values.kind() == arrow::compute::Datum::ARRAY);

--- a/src/utils/arrow_compute_wrappers.cpp
+++ b/src/utils/arrow_compute_wrappers.cpp
@@ -23,6 +23,7 @@ void apply_filter(
                                             filter.make_array(),
                                             filter_options,
                                             out);
+            break;
         }
         case arrow::compute::Datum::CHUNKED_ARRAY: {
             status = arrow::compute::Filter(&function_context,
@@ -30,6 +31,7 @@ void apply_filter(
                                             filter.chunked_array(),
                                             filter_options,
                                             out);
+            break;
         }
         default: {
             std::cerr << "Value kind not supported" << std::endl;

--- a/src/utils/arrow_compute_wrappers.h
+++ b/src/utils/arrow_compute_wrappers.h
@@ -7,22 +7,77 @@
 
 namespace hustle {
 
-// Filters are ChunkedArrays, indices are Arrays.
-
+/**
+ * A wrapper around Arrow's arrow::compute::Take() function that filters a datum
+ * with a boolean selection filter.
+ *
+ * By default, if a filter value is null, then the element will be filtered out.
+ * Arrow does allow us to emit null values if a filter value is null, but this
+ * function forces the default option. To give the user a choice, we would add
+ * arrow::compute::FilterOptions::NullSelectionBehavior options
+ * parameter to the function signature and update the internal filter options in
+ * this function's implementation.
+ *
+ * @param values Datum to filter
+ * @param filter A Boolean filter indicating which values should be filtered out.
+ * Must be of the same Datum kind as filter.
+ * @param out output datum. Will be the same Datum kind as values and filter.
+ */
 void apply_filter(
     const arrow::compute::Datum& values,
     const arrow::compute::Datum& filter,
     arrow::compute::Datum* out);
 
+/**
+ * A wrapper around Arrow's arrow::compute::Take() function that take from an
+ * array of values at indices in another array.
+ *
+ * By default, if an index is null, then the taken element of values will be
+ * null. Arrow currently does not support any other null semantics for Take.
+ *
+ * @param values datum from which to take
+ * @param indices indices of values that we want to take. Must be an Array
+ * @param out output datum
+ */
 void apply_indices(
     const arrow::compute::Datum& values,
     const arrow::compute::Datum& indices,
     arrow::compute::Datum* out);
 
-void sort_datum(const arrow::compute::Datum& values, arrow::compute::Datum* out);
 
+/**
+ * A wrapper around Arrow's arrow::compute::SortToIndices() function that
+ * performs an indirect sort of the input. The output contains indices that would
+ * sort the input, which would be the same length as the input.
+ *
+ * Nulls are be stably partitioned to the end of the output.
+ *
+ * @param values values to sort. Must be an Array
+ * @param out indices that would sort values
+ */
 void sort_to_indices(const arrow::compute::Datum& values, arrow::compute::Datum* out);
 
+/**
+ * A wrapper around Arrow's arrow::compute::SortToIndices() and
+ * arrow::compute::Take() that performs a direct sort on the input.
+ *
+ * This works by first calling sort_to_indices() to indirectly sort the input.
+ * Then, we call apply_indices() to actually sort the input values.
+ *
+ * @param values Values to be sorted. Must be an Array.
+ * @param out sorted values array.
+ */
+void sort_datum(const arrow::compute::Datum& values, arrow::compute::Datum* out);
+
+/**
+ * A wrapper around Arrow's arrow::compute::Compare() function that compare a
+ * numeric array with a scalar.
+ *
+ * @param left datum to compare, must be an Array
+ * @param right datum to compare, must be a Scalar of the ssame type as left Datum
+ * @param compare_operator comparison operator between left and right
+ * @param out output filter
+ */
 void compare(
     const arrow::compute::Datum& left,
     const arrow::compute::Datum& right,

--- a/src/utils/arrow_compute_wrappers.h
+++ b/src/utils/arrow_compute_wrappers.h
@@ -23,6 +23,11 @@ void sort_datum(const arrow::compute::Datum& values, arrow::compute::Datum* out)
 
 void sort_to_indices(const arrow::compute::Datum& values, arrow::compute::Datum* out);
 
+void compare(
+    const arrow::compute::Datum& left,
+    const arrow::compute::Datum& right,
+    arrow::compute::CompareOperator compare_operator,
+    arrow::compute::Datum* out);
 }
 
 #endif //HUSTLE_ARROW_COMPUTE_WRAPPERS_H

--- a/src/utils/arrow_compute_wrappers.h
+++ b/src/utils/arrow_compute_wrappers.h
@@ -19,7 +19,9 @@ void apply_indices(
     const arrow::compute::Datum& indices,
     arrow::compute::Datum* out);
 
-void sort_to_indices(const arrow::compute::Datum& values, arrow::compute::Datum* offsets);
+void sort_datum(const arrow::compute::Datum& values, arrow::compute::Datum* out);
+
+//void sort_to_indices(const arrow::compute::Datum& values, arrow::compute::Datum* out);
 
 void sort_to_indices(const std::shared_ptr<arrow::Array>& values, std::shared_ptr<arrow::Array>* out);
 

--- a/src/utils/arrow_compute_wrappers.h
+++ b/src/utils/arrow_compute_wrappers.h
@@ -83,6 +83,16 @@ void compare(
     const arrow::compute::Datum& right,
     arrow::compute::CompareOperator compare_operator,
     arrow::compute::Datum* out);
+
+void unique(const arrow::compute::Datum& values, arrow::compute::Datum* out);
+
+
+
+
+
+
+
 }
+
 
 #endif //HUSTLE_ARROW_COMPUTE_WRAPPERS_H

--- a/src/utils/arrow_compute_wrappers.h
+++ b/src/utils/arrow_compute_wrappers.h
@@ -1,0 +1,26 @@
+#ifndef HUSTLE_ARROW_COMPUTE_WRAPPERS_H
+#define HUSTLE_ARROW_COMPUTE_WRAPPERS_H
+
+#include <arrow/api.h>
+#include <arrow/compute/api.h>
+
+
+namespace hustle {
+
+void apply_filter(
+    const arrow::compute::Datum& values,
+    const arrow::compute::Datum& filter,
+    arrow::compute::Datum* out);
+
+void apply_indices(
+    const std::shared_ptr<arrow::ChunkedArray>& values,
+    const arrow::compute::Datum& indices,
+    std::shared_ptr<arrow::ChunkedArray>* out);
+
+
+
+
+
+}
+
+#endif //HUSTLE_ARROW_COMPUTE_WRAPPERS_H

--- a/src/utils/arrow_compute_wrappers.h
+++ b/src/utils/arrow_compute_wrappers.h
@@ -21,9 +21,7 @@ void apply_indices(
 
 void sort_datum(const arrow::compute::Datum& values, arrow::compute::Datum* out);
 
-//void sort_to_indices(const arrow::compute::Datum& values, arrow::compute::Datum* out);
-
-void sort_to_indices(const std::shared_ptr<arrow::Array>& values, std::shared_ptr<arrow::Array>* out);
+void sort_to_indices(const arrow::compute::Datum& values, arrow::compute::Datum* out);
 
 }
 

--- a/src/utils/arrow_compute_wrappers.h
+++ b/src/utils/arrow_compute_wrappers.h
@@ -7,19 +7,17 @@
 
 namespace hustle {
 
+// Filters are ChunkedArrays, indices are Arrays.
+
 void apply_filter(
     const arrow::compute::Datum& values,
     const arrow::compute::Datum& filter,
     arrow::compute::Datum* out);
 
 void apply_indices(
-    const std::shared_ptr<arrow::ChunkedArray>& values,
+    const arrow::compute::Datum& values,
     const arrow::compute::Datum& indices,
-    std::shared_ptr<arrow::ChunkedArray>* out);
-
-
-
-
+    arrow::compute::Datum* out);
 
 }
 

--- a/src/utils/arrow_compute_wrappers.h
+++ b/src/utils/arrow_compute_wrappers.h
@@ -19,6 +19,10 @@ void apply_indices(
     const arrow::compute::Datum& indices,
     arrow::compute::Datum* out);
 
+void sort_to_indices(const arrow::compute::Datum& values, arrow::compute::Datum* offsets);
+
+void sort_to_indices(const std::shared_ptr<arrow::Array>& values, std::shared_ptr<arrow::Array>* out);
+
 }
 
 #endif //HUSTLE_ARROW_COMPUTE_WRAPPERS_H

--- a/src/utils/arrow_compute_wrappers.h
+++ b/src/utils/arrow_compute_wrappers.h
@@ -84,6 +84,13 @@ void compare(
     arrow::compute::CompareOperator compare_operator,
     arrow::compute::Datum* out);
 
+/**
+ * A wrapper around Arrow's arrow::compute::Unique() function that computes the
+ * unique elements from an array-like object.
+ *
+ * @param values Array or ChunkedArray of values.
+ * @param out unique values of values as an Array.
+ */
 void unique(const arrow::compute::Datum& values, arrow::compute::Datum* out);
 
 


### PR DESCRIPTION
* I added wrapper function for calls to many `arrow::compute` functions to make operator code easier to read. These wrapper functions are in src/utils/arrow_compute_wrappers.*
* These wrappers are nice, because if the Arrow API changes, we only need to update the code in one file. Wes McKinney actually made a huge PR last week that completely changed the layout of Arrow's compute functions, so if we want to want to pull the most recent version of Arrow, refactoring will be much easier.

* All operators now have complete doc comments, and I added more comments to the source files to explain some of the less obvious implementation details. If anything regarding the operators is unclear, let me know, and I'll make some additions. 